### PR TITLE
Make gridxRowOver rules more specific

### DIFF
--- a/resources/basic.css
+++ b/resources/basic.css
@@ -112,7 +112,7 @@
 	-khtml-box-sizing: border-box; /* konqueror */
 }
 
-.gridxBodyRowHoverEffect .gridxRowOver .gridxRowTable {
+.gridxBodyRowHoverEffect .gridxRowOver > .gridxRowTable {
 	background-color: #cee8f2;
 }
 

--- a/resources/claro/basic.css
+++ b/resources/claro/basic.css
@@ -12,8 +12,8 @@
 .claro .gridxRowOdd .gridxRowTable {
 	background-color: #f1f8ff;
 }
-.claro .gridxBodyRowHoverEffect .gridxRowOver .gridxRowTable,
-.claro .gridxBodyRowHoverEffect .gridxRowOver .gridxCell {
+.claro .gridxBodyRowHoverEffect .gridxRowOver > .gridxRowTable,
+.claro .gridxBodyRowHoverEffect .gridxRowOver > .gridxCell {
 	background:url("../images/row_back.png") #ABD6FF repeat-x;
 }
 


### PR DESCRIPTION
This way, if we include another grid inside a dod pane
the highlighting of the inner grid will not be affected
when the outer grid is highlighted
