### PR TITLE
Fix issue caused by row IDs having quotes in them

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -220,8 +220,12 @@ define([
 		_onResizeEnd: function(){},
 
 		_escapeId: function(id){
-			return String(id).replace(/\\/g, "\\\\");
+			return String(id).replace(/\\/g, "\\\\").replace(/\"/g, "\\\"");
 		},
+
+                _escapeIdHtml: function(id){
+                        return String(id).replace(/\\/g, "\\\\").replace(/\"/g, "&quot;");
+                },
 
 		//event handling begin
 		_compNames: ['Cell', 'HeaderCell', 'Row', 'Header'],

--- a/modules/Body.js
+++ b/modules/Body.js
@@ -710,6 +710,7 @@ define([
 		},
 
 		_buildRows: function(start, count, uncachedRows, renderedRows){
+                        var escapeIdHtml = this.grid._escapeIdHtml;
 			var t = this,
 				end = start + count,
 				s = [],
@@ -724,9 +725,9 @@ define([
 					'" role="row" visualindex="', i);
 				if(row){
 					t.model.keep(row.id);
-					s.push('" rowid="', row.id,
+					s.push('" rowid="', escapeIdHtml(row.id),
 						'" rowindex="', rowInfo.rowIndex,
-						'" parentid="', rowInfo.parentId,
+						'" parentid="', escapeIdHtml(rowInfo.parentId),
 						'">', t._buildCells(row, i, columns),
 					'</div>');
 					renderedRows.push(row);


### PR DESCRIPTION
I hit a problem with row IDs containing quote chars - gridx would fail to render. Please see the attached changes, the problem is caused by not escaping quote chars when building row html.
