### PR TITLE
Update _Dnd.js

### DIFF
--- a/modules/dnd/_Dnd.js
+++ b/modules/dnd/_Dnd.js
@@ -185,6 +185,7 @@ define([
 			if(this._dndReady && !this._dndBegun){
 				this._loadSelectStatus();
 				this._dndReady = 0;	//0 as false
+				t._source.notSelectText = 0;
 				domClass.remove(win.body(), 'gridxDnDReadyCursor');
 			}
 		},


### PR DESCRIPTION
need to reset the notSelectText flag when dissmissDndReady, otherwise if we just mouseover the header and do no drag, then we can not select text in grid
