### PR TITLE
Optimize selection peformance

### DIFF
--- a/modules/Body.js
+++ b/modules/Body.js
@@ -330,6 +330,8 @@ define([
 
 		autoUpdate: true,
 
+		renderredIds: {},
+
 		compareOnSet: function(v1, v2){
 			return typeof v1 == 'object' && typeof v2 == 'object' ?
 				json.toJson(v1) == json.toJson(v2) :
@@ -403,6 +405,9 @@ define([
 			delete t._err;
 			clearTimeout(t._sizeChangeHandler);
 			domClass.toggle(t.domNode, 'gridxBodyRowHoverEffect', t.arg('rowHoverEffect'));
+
+			// cache visual ids
+			t.renderredIds = {};
 			
 			// domClass.add(loadingNode, 'gridxLoading');
 			t._showLoadingMask();
@@ -753,6 +758,7 @@ define([
 					row = g.row(rowInfo.rowId, 1);
 				s.push('<div class="gridxRow ', i % 2 ? 'gridxRowOdd' : '',
 					'" role="row" visualindex="', i);
+				t.renderredIds[rowInfo.rowId] = 1;
 				if(row){
 					t.model.keep(row.id);
 					s.push('" rowid="', encode(row.id),
@@ -795,6 +801,7 @@ define([
 					n.setAttribute('rowindex', rowInfo.rowIndex);
 					n.setAttribute('parentid', rowInfo.parentId || '');
 					n.innerHTML = t._buildCells(row, rowInfo.visualIndex);
+					t.renderredIds[row.id] = 1;
 					t.onAfterRow(row);
 				}else{
 					console.error('Error in Body._buildRowContent: Row is not in cache: ' + rowInfo.rowIndex);

--- a/modules/extendedSelect/Row.js
+++ b/modules/extendedSelect/Row.js
@@ -354,7 +354,7 @@ define([
 		},
 
 		_onMark: function(id, toMark, oldState, type){
-			if(type == 'select'){
+			if(type == 'select' && this.grid.body.renderredIds[id]){
 				var nodes = query('[rowid="' + this.grid._escapeId(id) + '"]', this.grid.mainNode);
 				if(nodes.length){
 					nodes.forEach(function(node){

--- a/modules/extendedSelect/_Base.js
+++ b/modules/extendedSelect/_Base.js
@@ -173,16 +173,20 @@ define([
 		},
 
 		_highlight: function(target){
-			var t = this;
-			if(t._selecting){
+			var t = this,
+				g = t.grid;
+			if(t._selecting && t._lastStartItem != target){
 				var type = t._type,
 					start = t._startItem,
 					current = t._currentItem,
 					highlight = function(from, to, toHL){
 						from = from[type];
 						to = to[type];
-						var dir = from < to ? 1 : -1;
+						var dir = from < to ? 1 : -1,
+							start = g.body.renderStart, 
+							end = start + g.body.renderCount;
 						for(; from != to; from += dir){
+							if (from < start || from > end) continue;
 							var item = {};
 							item[type] = from;
 							t._highlightSingle(item, toHL);


### PR DESCRIPTION
- _Base.js:_highlight() line 186, avoid highlighting rows which is out of the body
- _Base.js:_highlight() line 178, make sure do highlighting once on one item
- Row.js:_onMark line 356, avoid query rows which is out of the body
- body:_buildRowContent(), _buildRows(), save renderred row ids.
- body:refresh(), clear saved rednerred row ids.
