### PR TITLE
Single quotes have to be escaped as well

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -220,7 +220,7 @@ define([
 		_onResizeEnd: function(){},
 
 		_escapeId: function(id){
-			return String(id).replace(/\\/g, "\\\\").replace(/\"/g, "\\\"");
+			return String(id).replace(/\\/g, "\\\\").replace(/\"/g, "\\\"").replace(/\'/g, "\\\'");
 		},
 
 		_encodeHTML: function(id){


### PR DESCRIPTION
Looks like I missed out on a need to escape single quotes as well, when escaping IDs.
