### PR TITLE
Fix row select issue with  select.row.selectById() when multiple = false

### DIFF
--- a/core/model/extensions/Mark.js
+++ b/core/model/extensions/Mark.js
@@ -85,7 +85,13 @@ define([
 		},
 
 		clearMark: function(type){
-			this._byId[this._initMark(type)] = {};
+			var tp = this._initMark(type);
+			var k = Object.keys(this._byId[tp]);
+			for (var i=0; i<k.length; i++){
+				if (this._byId[tp][k[i]] === 2) {
+					this._doMark(k[i], tp, 0);
+				};
+			}
 		},
 
 		getMarkedIds: function(type, includePartial){


### PR DESCRIPTION
I've found, clearMark isn't working properly. With this dirty fix one can use the single select feature or select/row. This fixes issues with select.row.selectById().
When I set select.row.multiple to false, single selection with mouse (on row header) works fine. But when I issue  select.row.selectById() then the original selection remains visible, plus the new one is selected.
