### PR TITLE
FilterBar: translations of &hellips; are now inserted as template

### DIFF
--- a/nls/ar/gridx.js
+++ b/nls/ar/gridx.js
@@ -147,7 +147,7 @@ define({
 //QuickFilter
 	filterLabel: 'ترشيح البيانات',
 	clearButtonTitle: 'محو مرشح البيانات',
-	buildFilterMenuLabel: 'بناء مرشح بيانات &hellip;',
+	buildFilterMenuLabel: 'بناء مرشح بيانات …',
 	apply: 'تطبيق مرشح البيانات',
 
 //Sort

--- a/nls/bg/gridx.js
+++ b/nls/bg/gridx.js
@@ -147,7 +147,7 @@ define({
 //QuickFilter
 	filterLabel: 'Филтър',
 	clearButtonTitle: 'Изчистване на филтър',
-	buildFilterMenuLabel: 'Вграждане на филтър&hellip;',
+	buildFilterMenuLabel: 'Вграждане на филтър…',
 	apply: 'Прилагане на филтър',
 
 //Sort

--- a/nls/ca/gridx.js
+++ b/nls/ca/gridx.js
@@ -147,7 +147,7 @@ define({
 //QuickFilter
 	filterLabel: 'Filtra',
 	clearButtonTitle: 'Esborra filtre',
-	buildFilterMenuLabel: 'Crea filtre&hellip;',
+	buildFilterMenuLabel: 'Crea filtre…',
 	apply: 'Aplica filtre',
 
 //Sort

--- a/nls/cs/gridx.js
+++ b/nls/cs/gridx.js
@@ -147,7 +147,7 @@ define({
 //QuickFilter
 	filterLabel: 'Filtr',
 	clearButtonTitle: 'Vymazat filtr',
-	buildFilterMenuLabel: 'Sestavit filtr&hellip;',
+	buildFilterMenuLabel: 'Sestavit filtr…',
 	apply: 'Použít filtr',
 
 //Sort

--- a/nls/da/gridx.js
+++ b/nls/da/gridx.js
@@ -147,7 +147,7 @@ define({
 //QuickFilter
 	filterLabel: 'Filter',
 	clearButtonTitle: 'Ryd filter',
-	buildFilterMenuLabel: 'Byg filter&hellip;',
+	buildFilterMenuLabel: 'Byg filter…',
 	apply: 'Anvend filter',
 
 //Sort

--- a/nls/de/gridx.js
+++ b/nls/de/gridx.js
@@ -147,7 +147,7 @@ define({
 //QuickFilter
 	filterLabel: 'Filter',
 	clearButtonTitle: 'Filter löschen',
-	buildFilterMenuLabel: 'Filter erstellen&hellip;',
+	buildFilterMenuLabel: 'Filter erstellen…',
 	apply: 'Filter anwenden',
 
 //Sort

--- a/nls/uk/gridx.js
+++ b/nls/uk/gridx.js
@@ -147,7 +147,7 @@ define({
 //QuickFilter
 	filterLabel: 'Фільтр',
 	clearButtonTitle: 'Очистити фільтр',
-	buildFilterMenuLabel: 'Визначити фільтр&hellip;',
+	buildFilterMenuLabel: 'Визначити фільтр…',
 	apply: 'Застосувати фільтр',
 
 //Sort

--- a/nls/vi/gridx.js
+++ b/nls/vi/gridx.js
@@ -147,7 +147,7 @@ define({
 //QuickFilter
 	filterLabel: 'Bộ lọc',
 	clearButtonTitle: 'Xóa bộ lọc',
-	buildFilterMenuLabel: 'Tạo bộ lọc&hellip;',
+	buildFilterMenuLabel: 'Tạo bộ lọc…',
 	apply: 'Áp dụng bộ lọc',
 
 //Sort

--- a/nls/zh-tw/gridx.js
+++ b/nls/zh-tw/gridx.js
@@ -147,7 +147,7 @@ define({
 //QuickFilter
 	filterLabel: '過濾器',
 	clearButtonTitle: '清除過濾器',
-	buildFilterMenuLabel: '建置過濾器&hellip;',
+	buildFilterMenuLabel: '建置過濾器…',
 	apply: '套用過濾器',
 
 //Sort


### PR DESCRIPTION
Hello,

it is a trivial bugfix (although it seems to have some security implications, it is simply not true). The nls files of the QuickFilter Bar contained the "buildFilterMenuLabel" id, which contained an escaped "&hellip;" string. But this nls string was simply included into the template templates/QuickFilter.html (and it is used only there), whose variable substitution seems to do this escaping functionality yet again. The result was the appearance of the "&amp;hellip;" string, instead of a "…" in the popup menu of the quickfilter Bar.

The trivial solution was the removal of the double-escaping, and this is what I suggest to you.

good luck,

Peter Horvath
