### PR TITLE
Fixes to extendedSelect and TouchScroll

### DIFF
--- a/modules/RowHeader.js
+++ b/modules/RowHeader.js
@@ -295,7 +295,7 @@ define([
 				brn && n;
 				brn = brn.nextSibling, n = n.nextSibling){
 					bn = this.grid.dod ? brn : brn.firstChild;
-					var h = ie > 8 ? domStyle.getComputedStyle(bn).height : bn.offsetHeight + 'px';
+					var h = ie > 8 ? domStyle.getComputedStyle(bn).height : bn.clientHeight + 'px';
 					n.style.height = n.firstChild.style.height = h;
 			}
 

--- a/modules/TouchScroll.js
+++ b/modules/TouchScroll.js
@@ -5,8 +5,9 @@ define([
 	"dojo/dom",
 	"dojo/dom-construct",
 	"dojo/touch",
+	"dojo/has",
 	"../core/_Module"
-], function(declare, win, event, dom, domConstruct, touch, _Module){
+], function(declare, win, event, dom, domConstruct, touch, has, _Module){
 
 /*=====
 	return declare(_Module, {
@@ -51,8 +52,7 @@ define([
 				vScrollerNode = g.vScrollerNode,
 				hScrollerNode = g.hScrollerNode;
 			//Start touch scroll only on mobile devices where the scroll bar can not be shown
-			if((vScrollerNode.style.display != 'none' && vScrollerNode.offsetWidth == 1) ||
-				(hScrollerNode.style.display != 'none' && hScrollerNode.offsetHeight == 1)){
+			if(has('touch')) {
 				var vns = t.vInner.style,
 					hns = t.hInner.style,
 					bn = g.bodyNode,


### PR DESCRIPTION
When custom styling is used on grids, the row height and the extendedSelect checkbox cell heights would not match. Switch to clientHeight instead of offSetHeight.

TouchScroll -- The if condition to enable touchscroll was not being triggered on an iPad with iOS 8.3. Just switching to has("touch") as it's a better way to detect a touchscreen.
