### PR TITLE
Unbreak height computation on non-IE

### DIFF
--- a/modules/RowHeader.js
+++ b/modules/RowHeader.js
@@ -290,14 +290,14 @@ define([
 		},
 
 		_onResize: function(){
-			var ie = has('ie')? has('ie') : has('trident')? 11 : false, 
+			var ie = has('ie')? has('ie') : has('trident')? 11 : undefined,
 				bn;
 
 			for(var brn = this.grid.bodyNode.firstChild, n = this.bodyNode.firstChild;
 				brn && n;
 				brn = brn.nextSibling, n = n.nextSibling){
 					bn = this.grid.dod ? brn : brn.firstChild;
-					var h = ie > 8 ? domStyle.getComputedStyle(bn).height : bn.offsetHeight + 'px';
+					var h = ie <= 8 ? bn.offsetHeight + 'px' : domStyle.getComputedStyle(bn).height;
 					n.style.height = n.firstChild.style.height = h;
 			}
 


### PR DESCRIPTION
Fix a regression introduced by 0863affbad32095eb09c18084ec5df73c1f88c19: On browsers other than IE, `ie` is set to `false` and since `false > 8` is not true, the row height was truncated. This would typically show up when using Grids inside a TabContainer, since the onShow event triggers a resize. The fix reorders the branch to match the corresponding order in `getHeight()`  earlier.