### PR TITLE
Google Closure Compiler upgrade: Removing duplicate object keys

### DIFF
--- a/nls/ar/gridx.js
+++ b/nls/ar/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "و",
 	"or": "أو",
-	"addRuleButton": "اضافة قاعدة",
 	"waiAddRuleButton": "اضافة قاعدة جديدة",
 	"removeRuleButton": "ازالة قاعدة",
 	"waiRemoveRuleButtonTemplate": "ازالة قاعدة ${0}",

--- a/nls/bg/gridx.js
+++ b/nls/bg/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "и",
 	"or": "или",
-	"addRuleButton": "Добавяне на правило",
 	"waiAddRuleButton": "Добавяне на ново правило",
 	"removeRuleButton": "Премахване на правило",
 	"waiRemoveRuleButtonTemplate": "Премахване на правило ${0}",

--- a/nls/bs/gridx.js
+++ b/nls/bs/gridx.js
@@ -43,7 +43,6 @@ define({
 	"relationMsgTail": "",
 	"and": "i",
 	"or": "ili",
-	"addRuleButton": "Dodaj pravilo",
 	"waiAddRuleButton": "Dodaj novo pravilo",
 	"removeRuleButton": "Ukloni pravilo",
 	"waiRemoveRuleButtonTemplate": "Ukloni pravilo ${0}",

--- a/nls/ca/gridx.js
+++ b/nls/ca/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "i",
 	"or": "o",
-	"addRuleButton": "Afegeix regla",
 	"waiAddRuleButton": "Afegeix una nova regla",
 	"removeRuleButton": "Elimina la regla",
 	"waiRemoveRuleButtonTemplate": "Elimina la regla ${0}",

--- a/nls/cs/gridx.js
+++ b/nls/cs/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "a",
 	"or": "nebo",
-	"addRuleButton": "Přidat pravidlo",
 	"waiAddRuleButton": "Přidat nové pravidlo",
 	"removeRuleButton": "Odebrat pravidlo",
 	"waiRemoveRuleButtonTemplate": "Odebrat pravidlo ${0}",

--- a/nls/da/gridx.js
+++ b/nls/da/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "og",
 	"or": "eller",
-	"addRuleButton": "Tilføj regel",
 	"waiAddRuleButton": "Tilføj en ny regel",
 	"removeRuleButton": "Fjern regel",
 	"waiRemoveRuleButtonTemplate": "Fjern reglen ${0}",

--- a/nls/de/gridx.js
+++ b/nls/de/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "und",
 	"or": "oder",
-	"addRuleButton": "Regel hinzufügen",
 	"waiAddRuleButton": "Neue Regel hinzufügen",
 	"removeRuleButton": "Regel entfernen",
 	"waiRemoveRuleButtonTemplate": "Regel ${0} entfernen",

--- a/nls/el/gridx.js
+++ b/nls/el/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "και",
 	"or": "ή",
-	"addRuleButton": "Προσθήκη κανόνα",
 	"waiAddRuleButton": "Προσθήκη νέου κανόνα",
 	"removeRuleButton": "Αφαίρεση κανόνα",
 	"waiRemoveRuleButtonTemplate": "Αφαίρεση του κανόνα ${0}",

--- a/nls/es/gridx.js
+++ b/nls/es/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "y",
 	"or": "o",
-	"addRuleButton": "Añadir regla",
 	"waiAddRuleButton": "Añadir una regla nueva",
 	"removeRuleButton": "Eliminar regla",
 	"waiRemoveRuleButtonTemplate": "Eliminar regla ${0}",

--- a/nls/eu/gridx.js
+++ b/nls/eu/gridx.js
@@ -43,7 +43,6 @@ define({
 	"relationMsgTail": "",
 	"and": "eta",
 	"or": "edo",
-	"addRuleButton": "Gehitu araua",
 	"waiAddRuleButton": "Gehitu arau berria",
 	"removeRuleButton": "Kendu araua",
 	"waiRemoveRuleButtonTemplate": "Kendu ${0} araua",

--- a/nls/fi/gridx.js
+++ b/nls/fi/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": " -",
 	"or": "tai",
-	"addRuleButton": "Lisää sääntö",
 	"waiAddRuleButton": "Lisää uusi sääntö",
 	"removeRuleButton": "Poista sääntö",
 	"waiRemoveRuleButtonTemplate": "Poista sääntö ${0}",

--- a/nls/fr/gridx.js
+++ b/nls/fr/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "et",
 	"or": "ou",
-	"addRuleButton": "Ajouter une règle",
 	"waiAddRuleButton": "Ajouter une nouvelle règle",
 	"removeRuleButton": "Supprimer une règle",
 	"waiRemoveRuleButtonTemplate": "Supprimer la règle ${0}",

--- a/nls/gridx.js
+++ b/nls/gridx.js
@@ -55,7 +55,6 @@ define({root:
 	"and": "and",
 	"or": "or",
 	
-	"addRuleButton": "Add Rule",
 	"waiAddRuleButton": "Add a new rule",
 	"removeRuleButton": "Remove Rule",
 	"waiRemoveRuleButtonTemplate": "Remove rule ${0}",

--- a/nls/he/gridx.js
+++ b/nls/he/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "וגם",
 	"or": "או",
-	"addRuleButton": "הוספת כלל",
 	"waiAddRuleButton": "הוספת כלל חדש",
 	"removeRuleButton": "סילוק כלל",
 	"waiRemoveRuleButtonTemplate": "סילוק הכלל ${0}",

--- a/nls/hr/gridx.js
+++ b/nls/hr/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "i",
 	"or": "ili",
-	"addRuleButton": "Dodaj pravilo",
 	"waiAddRuleButton": "Dodaj novo pravilo",
 	"removeRuleButton": "Ukloni pravilo",
 	"waiRemoveRuleButtonTemplate": "Ukloni pravilo ${0}",

--- a/nls/hu/gridx.js
+++ b/nls/hu/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "és",
 	"or": "vagy",
-	"addRuleButton": "Szabály hozzáadása",
 	"waiAddRuleButton": "Új szabály hozzáadása",
 	"removeRuleButton": "Szabály eltávolítása",
 	"waiRemoveRuleButtonTemplate": "${0} szabály eltávolítása",

--- a/nls/id/gridx.js
+++ b/nls/id/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "dan",
 	"or": "atau",
-	"addRuleButton": "Tambahkan Aturan",
 	"waiAddRuleButton": "Tambahkan aturan baru",
 	"removeRuleButton": "Hapus Aturan",
 	"waiRemoveRuleButtonTemplate": "Hapus aturan ${0}",

--- a/nls/it/gridx.js
+++ b/nls/it/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "and",
 	"or": "or",
-	"addRuleButton": "Aggiungi regola",
 	"waiAddRuleButton": "Aggiungi una nuova regola",
 	"removeRuleButton": "Rimuovi regola",
 	"waiRemoveRuleButtonTemplate": "Rimuovi regola ${0}",

--- a/nls/ja/gridx.js
+++ b/nls/ja/gridx.js
@@ -61,7 +61,6 @@ define({
 	"relationMsgTail": "",
 	"and": "かつ",
 	"or": "または",
-	"addRuleButton": "規則の追加",
 	"waiAddRuleButton": "新規規則の追加",
 	"removeRuleButton": "規則の削除",
 	"waiRemoveRuleButtonTemplate": "規則 ${0} の削除",

--- a/nls/kk/gridx.js
+++ b/nls/kk/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "және",
 	"or": "немесе",
-	"addRuleButton": "Ережені қосу",
 	"waiAddRuleButton": "Жаңа ережені қосу",
 	"removeRuleButton": "Ережені жою",
 	"waiRemoveRuleButtonTemplate": "Ережені жою ${0}",

--- a/nls/ko/gridx.js
+++ b/nls/ko/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "및",
 	"or": "또는",
-	"addRuleButton": "규칙 추가",
 	"waiAddRuleButton": "새 규칙 추가",
 	"removeRuleButton": "규칙 제거",
 	"waiRemoveRuleButtonTemplate": "규칙 ${0} 제거",

--- a/nls/mk/gridx.js
+++ b/nls/mk/gridx.js
@@ -43,7 +43,6 @@ define({
 	"relationMsgTail": "",
 	"and": "и",
 	"or": "или",
-	"addRuleButton": "Додај правило",
 	"waiAddRuleButton": "Додај ново правило",
 	"removeRuleButton": "Отстрани правило",
 	"waiRemoveRuleButtonTemplate": "тстрани го правилото ${0}",

--- a/nls/nb/gridx.js
+++ b/nls/nb/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "og",
 	"or": "eller",
-	"addRuleButton": "Legg til regel",
 	"waiAddRuleButton": "Legg til en ny regel",
 	"removeRuleButton": "Fjern regel",
 	"waiRemoveRuleButtonTemplate": "Fjern regelen ${0}",

--- a/nls/nl/gridx.js
+++ b/nls/nl/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "en",
 	"or": "of",
-	"addRuleButton": "Regel toevoegen ",
 	"waiAddRuleButton": "Nieuwe regel toevoegen",
 	"removeRuleButton": "Regel verwijderen",
 	"waiRemoveRuleButtonTemplate": "Regel ${0} verwijderen",

--- a/nls/pl/gridx.js
+++ b/nls/pl/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "i",
 	"or": "lub",
-	"addRuleButton": "Dodaj regułę",
 	"waiAddRuleButton": "Dodaj nową regułę",
 	"removeRuleButton": "Usuń regułę",
 	"waiRemoveRuleButtonTemplate": "Usuń regułę ${0}",

--- a/nls/pt-pt/gridx.js
+++ b/nls/pt-pt/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "e",
 	"or": "ou",
-	"addRuleButton": "Adicionar regra",
 	"waiAddRuleButton": "Adicionar uma nova regra",
 	"removeRuleButton": "Remover Regra",
 	"waiRemoveRuleButtonTemplate": "Remover regra ${0}",

--- a/nls/pt/gridx.js
+++ b/nls/pt/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "e",
 	"or": "ou",
-	"addRuleButton": "Incluir Regra",
 	"waiAddRuleButton": "Incluir uma nova regra",
 	"removeRuleButton": "Remover Regra",
 	"waiRemoveRuleButtonTemplate": "Remover regra ${0}",

--- a/nls/ro/gridx.js
+++ b/nls/ro/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "şi",
 	"or": "sau",
-	"addRuleButton": "Adăugare regulă",
 	"waiAddRuleButton": "Adăugare regulă nouă",
 	"removeRuleButton": "Înlăturare regulă",
 	"waiRemoveRuleButtonTemplate": "Înlăturare regula ${0}",

--- a/nls/ru/gridx.js
+++ b/nls/ru/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "до",
 	"or": "или",
-	"addRuleButton": "Добавить правило",
 	"waiAddRuleButton": "Добавить новое правило",
 	"removeRuleButton": "Удалить правило",
 	"waiRemoveRuleButtonTemplate": "Удалить правило ${0}",

--- a/nls/sk/gridx.js
+++ b/nls/sk/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "a",
 	"or": "alebo",
-	"addRuleButton": "Pridať pravidlo",
 	"waiAddRuleButton": "Pridať nové pravidlo",
 	"removeRuleButton": "Odstrániť pravidlo",
 	"waiRemoveRuleButtonTemplate": "Odstrániť pravidlo ${0}",

--- a/nls/sl/gridx.js
+++ b/nls/sl/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "in",
 	"or": "ali",
-	"addRuleButton": "Dodaj pravilo",
 	"waiAddRuleButton": "Dodaj novo pravilo",
 	"removeRuleButton": "Odstrani pravilo",
 	"waiRemoveRuleButtonTemplate": "Odstrani pravilo ${0}",

--- a/nls/sr/gridx.js
+++ b/nls/sr/gridx.js
@@ -43,7 +43,6 @@ define({
 	"relationMsgTail": "",
 	"and": "i",
 	"or": "ili",
-	"addRuleButton": "Dodaj pravilo",
 	"waiAddRuleButton": "Dodaj novo pravilo",
 	"removeRuleButton": "Ukloni pravilo",
 	"waiRemoveRuleButtonTemplate": "Ukloni pravilo ${0}",

--- a/nls/sv/gridx.js
+++ b/nls/sv/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "och",
 	"or": "eller",
-	"addRuleButton": "Lägg till regel",
 	"waiAddRuleButton": "Lägg till ny regel",
 	"removeRuleButton": "Ta bort regel",
 	"waiRemoveRuleButtonTemplate": "Ta bort regel ${0}",

--- a/nls/th/gridx.js
+++ b/nls/th/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "และ",
 	"or": "หรือ",
-	"addRuleButton": "เพิ่มกฏ",
 	"waiAddRuleButton": "เพิ่มกฎใหม่",
 	"removeRuleButton": "ลบกฎ",
 	"waiRemoveRuleButtonTemplate": "ลบกฎ ${0}",

--- a/nls/tr/gridx.js
+++ b/nls/tr/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "ve",
 	"or": "veya",
-	"addRuleButton": "Kural Ekle",
 	"waiAddRuleButton": "Yeni kural ekle",
 	"removeRuleButton": "Kuralı kaldır",
 	"waiRemoveRuleButtonTemplate": "${0} kuralını kaldır",

--- a/nls/uk/gridx.js
+++ b/nls/uk/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "та",
 	"or": "або",
-	"addRuleButton": "Додати правило",
 	"waiAddRuleButton": "Додати нове правило",
 	"removeRuleButton": "Видалити правило",
 	"waiRemoveRuleButtonTemplate": "Видалити правило ${0}",

--- a/nls/vi/gridx.js
+++ b/nls/vi/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "và",
 	"or": "hoặc",
-	"addRuleButton": "Thêm quy tắc",
 	"waiAddRuleButton": "Thêm quy tắc mới",
 	"removeRuleButton": "Xóa quy tắc",
 	"waiRemoveRuleButtonTemplate": "Xóa quy tắc ${0}",

--- a/nls/zh-tw/gridx.js
+++ b/nls/zh-tw/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "及",
 	"or": "或",
-	"addRuleButton": "新增規則",
 	"waiAddRuleButton": "新增規則",
 	"removeRuleButton": "移除規則",
 	"waiRemoveRuleButtonTemplate": "移除規則 ${0}",

--- a/nls/zh/gridx.js
+++ b/nls/zh/gridx.js
@@ -45,7 +45,6 @@ define({
 	"relationMsgTail": "",
 	"and": "和",
 	"or": "或者",
-	"addRuleButton": "添加规则",
 	"waiAddRuleButton": "添加新规则",
 	"removeRuleButton": "除去规则",
 	"waiRemoveRuleButtonTemplate": "除去规则 ${0}",

--- a/tests/test_grid_edit.js
+++ b/tests/test_grid_edit.js
@@ -125,7 +125,7 @@ require([
 				props: 'minimum: 0, maximum: 1'
 			}
 		},
-		{ field: "Track", name:"Number Spinner", width: '100px', editable: true,
+		{ field: "Track", name:"Number Spinner", editable: true,
 			width: '50px',
 			editor: "dijit/form/NumberSpinner"
 		},

--- a/tests/test_grid_edit_lazy.js
+++ b/tests/test_grid_edit_lazy.js
@@ -126,7 +126,7 @@ require([
 				props: 'minimum: 0, maximum: 1'
 			}
 		},
-		{ field: "Track", name:"Number Spinner", width: '100px', editable: true,
+		{ field: "Track", name:"Number Spinner", editable: true,
 			width: '50px',
 			editor: "dijit/form/NumberSpinner"
 		},


### PR DESCRIPTION
Dojo 1.x uses currently the Google Closure Compiler v20160911.

It is currently impossible to upgrade the Google Closure Compiler to a newer version. The reason is — there is an incompatibility issue, when using the Google Closure Compiler to process Dojo applications: duplicate object keys.

This pull request introduces changes to the GridX's source code that remove all the occurrences of duplicate object keys in code.