### PR TITLE
Use array.filter for older browser compatibility

### DIFF
--- a/core/model/extensions/Mark.js
+++ b/core/model/extensions/Mark.js
@@ -324,9 +324,9 @@ define([
 				unmarkable = t._unmarkable[type];
 
 			//Fix defect 12877 
-			//Remove ubmarkable items
-			//which does not need toupdate
-			treePath = treePath.filter(function(childId){
+			//Remove unmarkable items
+			//which does not need to update
+			treePath = array.filter(treePath, function(childId){
 				return !(unmarkable && unmarkable[childId]);
 			});
 


### PR DESCRIPTION
Dojo's array.filter provides support for older browsers. Use it to prevent breaking compatility (IE<9).