### PR TITLE
[fix]: The clear function supports `silent` flag

### DIFF
--- a/modules/extendedSelect/_Base.js
+++ b/modules/extendedSelect/_Base.js
@@ -56,9 +56,9 @@ define([
 			var t = this, g = t.grid, doc = win.doc;
 			g.domNode.setAttribute('aria-multiselectable', true);
 			t._refSelectedIds = [];
-			t.subscribe('gridClearSelection_' + g.id, function(type){
+			t.subscribe('gridClearSelection_' + g.id, function(type, silent){
 				if(type != t._type){
-					t.clear();
+					t.clear(silent);
 				}
 			});
 			t.batchConnect(


### PR DESCRIPTION
The clear function supports `silent` flag, but we have not made it available in the event 'gridClearSelection_', this is useful as it gives us to control when we want to notify onSelectionChange event while clearing the selection.